### PR TITLE
Navbar covering content (solved)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,4 +1,5 @@
-/* MY EDITS: 1. Deleted CSS for Header/Navbar styling (because Bootstrap now provides this) 2. Deleted CSS for Work section 3. Set size of images (icons) in Skills section 4.Deleted CSS for About and Contact sections 5. Changed font-family in var() function. 6. Deleted global styling that’s no longer needed 7. Added custom styling to body, and p, h1-6, links and unordered lists/list items throughout the page (did this by targeting id on body, so overrides Bootstrap’s styling). 8. Added credit for this idea in comments. 9. Added important property to font-family (so completely overrides Bootstrap's styling) 10. Added styling to Footer, including hover effect to links/images (icons) 11. Added credit for box-shadow colour in comments.
+/* MY EDITS: 1. Deleted CSS for Header/Navbar styling (because Bootstrap now provides this) 2. Deleted CSS for Work section 3. Set size of images (icons) in Skills section 4.Deleted CSS for About and Contact sections 5. Changed font-family in var() function. 6. Deleted global styling that’s no longer needed 7. Added custom styling to body, and p, h1-6, links and unordered lists/list items throughout the page (did this by targeting id on body, so overrides Bootstrap’s styling). 8. Added credit for this idea in comments. 9. Added important property to font-family (so completely overrides Bootstrap's styling) 10. Added styling to Footer, including hover effect to links/images (icons) 11. Added credit for box-shadow colour in comments 12. Commented out existing media queries (so can inspect page’s responsiveness without/Bootstrap only) 13. Added padding to all h1-6 (so sticky navbar not covering content).
+
 
 */
 
@@ -22,6 +23,11 @@
   color: var(--dark);
   font-family: var(--font-family) !important;
   list-style-type: none;
+}
+
+/*Adds top padding to h1-h6 (so sticky Navbar doesn't cover content when navigating via links)*/
+#bootstrap-override h1,h2,h3,h4,h5,h6 {
+  padding-top: 55px;
 }
 
 /* **Header/Nav Bar - EMPTY** */
@@ -64,50 +70,51 @@
 
 /*No seperate media queries for Small (640px to 375px), as all elements displayed at Medium are still displayed at Small. Therefore below media queries actually apply for 376px to 1007px*/
 
-@media screen and (max-width: 1007px) {
+ /*@media screen and (max-width: 1007px) {
   /*Reduces font size in Header/Nav Bar*/
-  header h1, nav a {
+   /*header h1, nav a {
     font-size: 150%;
   }
 
   /*Reduces font size of main headers in About, Work and Contact; removes their margin*/
-  .about-header, #work-header, .contact-header {
+   /*.about-header, #work-header, .contact-header {
     font-size: 100%;
     margin-right: 0px;
   }
 
   /*No longer displays image (avatar) in About*/
-  .about-image {
+   /*.about-image {
     display: none;
   }
 
   /*Repositions text (takes up two coloums now) and resizes text in About*/
-  .about-text {
+   /*.about-text {
     grid-column: 2 / span 3;
     font-size: 100%;
   }
 
   /*Reduces font size of links in Contact*/
-  #contact a {
+   /*#contact a {
     font-size: 100%;
   }
 }
 
 /* *Mobile (smaller than 376px)* */
 
-@media screen and (max-width: 375px) {
+ /*@media screen and (max-width: 375px) {
   /*No longer displays Header/Nav Bar and main headers in About, Work and Contact*/
-  header,.about-header, #work-header, .contact-header  {
+  /* header,.about-header, #work-header, .contact-header  {
     display: none;
   }
 
   /*Repositions text in About (takes up three coloums now)*/
-   .about-text {
+   /* .about-text {
     grid-column: 1 / span 3;
   }
 
   /*Repositions Contact links (in unordered list) (take up two coloums now)*/
-  #contact ul {
+  /* #contact ul {
     grid-column: 1 / span 2;
   }
 }
+*/


### PR DESCRIPTION
CSS: Commented out existing media queries (so can inspect page’s responsiveness without these/only with Bootstrap’s responsiveness). Added padding to all h1-6 (so sticky navbar no longer covering content on navigation).
